### PR TITLE
Debian 13 compatibility

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,12 +6,12 @@
     value: "{{ item.value }}"
   loop:
     - key: PublicPort
-      value: "{{ jellyfin_HTTP_port }}"
+      value: "{{ jellyfin_HTTP_port | string }}"
     - key: PublicHttpsPort
-      value: "{{ jellyfin_HTTPS_port }}"
+      value: "{{ jellyfin_HTTPS_port | string }}"
     - key: HttpServerPortNumber
-      value: "{{ jellyfin_HTTP_port }}"
+      value: "{{ jellyfin_HTTP_port | string }}"
     - key: HttpsPortNumber
-      value: "{{ jellyfin_HTTPS_port }}"
+      value: "{{ jellyfin_HTTPS_port | string }}"
   notify: Restart Jellyfin
 ...

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,18 +9,12 @@
   retries: 3
   until: apt_result is succeeded
 
-- name: Checking to see if the Jellyfin PGP key is already present
-  ansible.builtin.stat:
-    path: /usr/share/keyrings/jellyfin.gpg.asc
-  register: keyring
-
 - name: Download Jellyfin Team GPG key
   ansible.builtin.get_url:
     url: https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
     checksum: sha256:a0cde241ae297fa6f0265c0bf15ce9eb9ee97c008904a59ab367a67d59532839
     dest: /usr/share/keyrings/jellyfin.gpg.asc
     mode: '644'
-  when: "'stat' in keyring and not keyring.stat.exists"
 
 - name: Add Jellyfin repository
   apt_repository:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,18 +9,23 @@
   retries: 3
   until: apt_result is succeeded
 
-- name: Import Jellyfin Team GPG key
-  apt_key:
+- name: Checking to see if the Jellyfin PGP key is already present
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/jellyfin.gpg.asc
+  register: keyring
+
+- name: Download Jellyfin Team GPG key
+  ansible.builtin.get_url:
     url: https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
-    state: present
-  register: apt_key_result
-  retries: 3
-  until: apt_key_result is succeeded
+    checksum: sha256:a0cde241ae297fa6f0265c0bf15ce9eb9ee97c008904a59ab367a67d59532839
+    dest: /usr/share/keyrings/jellyfin.gpg.asc
+    mode: '644'
+  when: "'stat' in keyring and not keyring.stat.exists"
 
 - name: Add Jellyfin repository
   apt_repository:
     repo: >
-      deb https://repo.jellyfin.org/{{ ansible_distribution | lower }}
+      deb [signed-by=/usr/share/keyrings/jellyfin.gpg.asc] https://repo.jellyfin.org/{{ ansible_distribution | lower }}
       {{ ansible_distribution_release }} main
     state: present
 


### PR DESCRIPTION
Closes #14 

The main change here was switching away from apt-key, but this also required setting the type of the ports to be a string to make the xml module happy. I don't think the latter is specific to Debian, but because it's a fix that is required, I included it here so I could test do end-to-end testing.