### PR TITLE
Use existing X.509 certs

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,12 +6,12 @@
     value: "{{ item.value }}"
   loop:
     - key: PublicPort
-      value: "{{ jellyfin_HTTP_port }}"
+      value: "{{ jellyfin_HTTP_port | string }}"
     - key: PublicHttpsPort
-      value: "{{ jellyfin_HTTPS_port }}"
+      value: "{{ jellyfin_HTTPS_port | string }}"
     - key: HttpServerPortNumber
-      value: "{{ jellyfin_HTTP_port }}"
+      value: "{{ jellyfin_HTTP_port | string }}"
     - key: HttpsPortNumber
-      value: "{{ jellyfin_HTTPS_port }}"
+      value: "{{ jellyfin_HTTPS_port | string }}"
   notify: Restart Jellyfin
 ...

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,18 +9,12 @@
   retries: 3
   until: apt_result is succeeded
 
-- name: Checking to see if the Jellyfin PGP key is already present
-  ansible.builtin.stat:
-    path: /usr/share/keyrings/jellyfin.gpg.asc
-  register: keyring
-
 - name: Download Jellyfin Team GPG key
   ansible.builtin.get_url:
     url: https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
     checksum: sha256:a0cde241ae297fa6f0265c0bf15ce9eb9ee97c008904a59ab367a67d59532839
     dest: /usr/share/keyrings/jellyfin.gpg.asc
     mode: '644'
-  when: "'stat' in keyring and not keyring.stat.exists"
 
 - name: Add Jellyfin repository
   apt_repository:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,18 +9,23 @@
   retries: 3
   until: apt_result is succeeded
 
-- name: Import Jellyfin Team GPG key
-  apt_key:
+- name: Checking to see if the Jellyfin PGP key is already present
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/jellyfin.gpg.asc
+  register: keyring
+
+- name: Download Jellyfin Team GPG key
+  ansible.builtin.get_url:
     url: https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
-    state: present
-  register: apt_key_result
-  retries: 3
-  until: apt_key_result is succeeded
+    checksum: sha256:a0cde241ae297fa6f0265c0bf15ce9eb9ee97c008904a59ab367a67d59532839
+    dest: /usr/share/keyrings/jellyfin.gpg.asc
+    mode: '644'
+  when: "'stat' in keyring and not keyring.stat.exists"
 
 - name: Add Jellyfin repository
   apt_repository:
     repo: >
-      deb https://repo.jellyfin.org/{{ ansible_distribution | lower }}
+      deb [signed-by=/usr/share/keyrings/jellyfin.gpg.asc] https://repo.jellyfin.org/{{ ansible_distribution | lower }}
       {{ ansible_distribution_release }} main
     state: present
 

--- a/templates/jellyfin.conf-apache2.j2
+++ b/templates/jellyfin.conf-apache2.j2
@@ -7,7 +7,7 @@
   ProxyPass /.well-known/acme-challenge/ !
 {% endif %}
 
-{% if jellyfin_generate_self_signed_certificate and jellyfin_redirect_HTTPS or jellyfin_letsencrypt and letsencrypt_certificate.stat.exists %}
+{% if jellyfin_redirect_HTTPS and (jellyfin_generate_self_signed_certificate or letsencrypt_certificate.stat.exists) %}
   Redirect permanent / https://{{ jellyfin_FQDN | first }}
 {% else %}
   ProxyPreserveHost On
@@ -20,14 +20,14 @@
 {% endif %}
 
 </VirtualHost>
-{% if jellyfin_generate_self_signed_certificate or jellyfin_letsencrypt and letsencrypt_certificate.stat.exists %}
+{% if jellyfin_generate_self_signed_certificate or letsencrypt_certificate.stat.exists %}
 <IfModule mod_ssl.c>
   <VirtualHost *:443>
     ServerName {{ jellyfin_FQDN | first }}
     ServerAlias {{ jellyfin_FQDN | join(' ') }}
 
     SSLEngine on
-{% if jellyfin_letsencrypt %}
+{% if letsencrypt_certificate.stat.exists %}
     SSLCertificateFile /etc/letsencrypt/live/{{ jellyfin_FQDN | first }}/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/{{ jellyfin_FQDN | first }}/privkey.pem
 {% else %}

--- a/templates/jellyfin.conf-nginx.j2
+++ b/templates/jellyfin.conf-nginx.j2
@@ -10,7 +10,7 @@ server {
     root /var/www/certbot;
   }
 {% endif %}
-{% if jellyfin_generate_self_signed_certificate and jellyfin_redirect_HTTPS or jellyfin_letsencrypt and letsencrypt_certificate.stat.exists %}
+{% if jellyfin_redirect_HTTPS and (jellyfin_generate_self_signed_certificate or letsencrypt_certificate.stat.exists) %}
   location / {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
@@ -43,11 +43,11 @@ server {
   }
 {% endif %}
 }
-{% if jellyfin_generate_self_signed_certificate or jellyfin_letsencrypt and letsencrypt_certificate.stat.exists %}
+{% if jellyfin_generate_self_signed_certificate or letsencrypt_certificate.stat.exists %}
 server {
   listen 443 ssl http2;
   server_name {{ jellyfin_FQDN | join(' ') }};
-{% if jellyfin_letsencrypt %}
+{% if letsencrypt_certificate.stat.exists %}
   ssl_certificate /etc/letsencrypt/live/{{ jellyfin_FQDN | first }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ jellyfin_FQDN | first }}/privkey.pem;
 {% else %}


### PR DESCRIPTION
Closes #16 

This change builds on the previous merge request https://github.com/HadrienPatte/ansible-role-jellyfin/pull/15

It also might be worth considering changing the default for `jellyfin_redirect_HTTPS` to true. The previous code redirects to HTTPS even when that is false in the event LetsEncrypt is enabled. This is unexpected behavior. After this patch, if `jellyfin_redirect_HTTPS` is false, it will not redirect to HTTPS. Changing the default to true would only actually enable the redirect if: `jellyfin_redirect_HTTPS` is true **and** we're either generating a self-signed cert or a certificate exists in the location where LetsEncrypt puts them.

This means that for users who don't use TLS, the redirect will not be present (which would be the expected behavior) even if the default for `jellyfin_redirect_HTTPS` is changed to true.