### PR TITLE
allow binding to localhost #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ None.
 
 * `jellyfin_HTTP_port`: HTTP port Jellyfin should bind to, defaults to `8096`
 * `jellyfin_HTTPS_port`: HTTPS port Jellyfin should bind to, defaults to `8920`
+* `jellyfin_bind_ip`: IP Jellyfin should bind to, default to "" (all interfaces)
 * `jellyfin_FQDN`: List of Fully Qualified Domain Names of the server
 * `jellyfin_HTTP_server`: HTTP reverse proxy server, possible values are
   `apache2` and `nginx`, defaults to `nginx`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,5 @@ jellyfin_redirect_HTTPS: false
 jellyfin_letsencrypt: false
 jellyfin_letsencrypt_email: admin@{{ jellyfin_FQDN | first }}
 jellyfin_remove_default: false
+jellyfin_bind_ip: ""
 ...

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,4 +14,14 @@
     - key: HttpsPortNumber
       value: "{{ jellyfin_HTTPS_port | string }}"
   notify: Restart Jellyfin
+- name: Configure Jellyfin networking
+  ansible.builtin.xml:
+    path: /etc/jellyfin/network.xml
+    xpath: /NetworkConfiguration/{{ item.key }}/string
+    value: "{{ item.value }}"
+  loop:
+    - key: LocalNetworkAddresses
+      value: "{{ jellyfin_bind_ip }}"
+  when: jellyfin_bind_ip is defined
+  notify: Restart Jellyfin
 ...


### PR DESCRIPTION
Closes #20 

I decided to keep backward compatibility (binding to all available interfaces) by default. If there's a desire to change the default behavior, update `defaults/main.yml` to set `jellyfin_bind_ip: 127.0.0.1` and update the README accordingly. I've tested it in both configurations and can confirm it'll work either way.